### PR TITLE
switch to individual exports to facilitate tree-shaking

### DIFF
--- a/browser/awaiting.js
+++ b/browser/awaiting.js
@@ -30,26 +30,24 @@
  * await a.delay(1000)
  */
 
-module.exports = {
-  delay,
-  time,
-  limit,
-  event,
-  callback,
-  single,
-  set,
-  list,
-  object,
-  map,
-  failure,
-  success,
-  result,
-  awaited,
-  awaitable: awaited,
-  throw: throwRejections,
-  swallow: swallowRejections,
-  ErrorList
-}
+module.exports.delay = delay
+module.exports.time = time
+module.exports.limit = limit
+module.exports.event = event
+module.exports.callback = callback
+module.exports.single = single
+module.exports.set = set
+module.exports.list = list
+module.exports.object = object
+module.exports.map = map
+module.exports.failure = failure
+module.exports.success = success
+module.exports.result = result
+module.exports.awaited = awaited
+module.exports.awaitable = awaited
+module.exports.throw = throwRejections
+module.exports.swallow = swallowRejections
+module.exports.ErrorList = ErrorList
 
 /**
  * Iterable Error type
@@ -117,9 +115,7 @@ ErrorList.prototype[Symbol.iterator] = function* () {
  * // => 5000
  */
 async function delay (ms) {
-  return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms)
-  })
+  return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 /**
@@ -432,9 +428,10 @@ async function map (list, concurrency, fn) {
  * })
  */
 async function failure (promise) {
-  return new Promise((resolve, reject) => {
-    promise.then(() => resolve(undefined)).catch(resolve)
-  })
+  return Promise.resolve()
+    .then(() => promise)
+    .then(() => undefined)
+    .catch(err => err)
 }
 
 /**
@@ -449,9 +446,9 @@ async function failure (promise) {
  * if (isNodeProject) doSomething()
  */
 async function success (promise) {
-  return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(undefined)) // eslint-disable-line
-  })
+  return Promise.resolve()
+    .then(() => promise)
+    .catch(() => undefined) // eslint-disable-line
 }
 
 /**
@@ -467,9 +464,9 @@ async function success (promise) {
  * $("#ajax-loader-animation").hide();
  */
 async function result (promise) {
-  return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(err))
-  })
+  return Promise.resolve()
+    .then(() => promise)
+    .catch(err => err)
 }
 
 /**

--- a/examples/awaiting.js
+++ b/examples/awaiting.js
@@ -30,26 +30,24 @@
  * await a.delay(1000)
  */
 
-module.exports = {
-  delay,
-  time,
-  limit,
-  event,
-  callback,
-  single,
-  set,
-  list,
-  object,
-  map,
-  failure,
-  success,
-  result,
-  awaited,
-  awaitable: awaited,
-  throw: throwRejections,
-  swallow: swallowRejections,
-  ErrorList
-}
+module.exports.delay = delay
+module.exports.time = time
+module.exports.limit = limit
+module.exports.event = event
+module.exports.callback = callback
+module.exports.single = single
+module.exports.set = set
+module.exports.list = list
+module.exports.object = object
+module.exports.map = map
+module.exports.failure = failure
+module.exports.success = success
+module.exports.result = result
+module.exports.awaited = awaited
+module.exports.awaitable = awaited
+module.exports.throw = throwRejections
+module.exports.swallow = swallowRejections
+module.exports.ErrorList = ErrorList
 
 /**
  * Iterable Error type
@@ -117,9 +115,7 @@ ErrorList.prototype[Symbol.iterator] = function* () {
  * // => 5000
  */
 async function delay (ms) {
-  return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms)
-  })
+  return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 /**
@@ -432,9 +428,10 @@ async function map (list, concurrency, fn) {
  * })
  */
 async function failure (promise) {
-  return new Promise((resolve, reject) => {
-    promise.then(() => resolve(undefined)).catch(resolve)
-  })
+  return Promise.resolve()
+    .then(() => promise)
+    .then(() => undefined)
+    .catch(err => err)
 }
 
 /**
@@ -449,9 +446,9 @@ async function failure (promise) {
  * if (isNodeProject) doSomething()
  */
 async function success (promise) {
-  return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(undefined)) // eslint-disable-line
-  })
+  return Promise.resolve()
+    .then(() => promise)
+    .catch(() => undefined) // eslint-disable-line
 }
 
 /**
@@ -467,9 +464,9 @@ async function success (promise) {
  * $("#ajax-loader-animation").hide();
  */
 async function result (promise) {
-  return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(err))
-  })
+  return Promise.resolve()
+    .then(() => promise)
+    .catch(err => err)
 }
 
 /**

--- a/lib/awaiting.js
+++ b/lib/awaiting.js
@@ -28,26 +28,24 @@
  * await a.delay(1000)
  */
 
-module.exports = {
-  delay,
-  time,
-  limit,
-  event,
-  callback,
-  single,
-  set,
-  list,
-  object,
-  map,
-  failure,
-  success,
-  result,
-  awaited,
-  awaitable: awaited,
-  throw: throwRejections,
-  swallow: swallowRejections,
-  ErrorList
-}
+module.exports.delay = delay
+module.exports.time = time
+module.exports.limit = limit
+module.exports.event = event
+module.exports.callback = callback
+module.exports.single = single
+module.exports.set = set
+module.exports.list = list
+module.exports.object = object
+module.exports.map = map
+module.exports.failure = failure
+module.exports.success = success
+module.exports.result = result
+module.exports.awaited = awaited
+module.exports.awaitable = awaited
+module.exports.throw = throwRejections
+module.exports.swallow = swallowRejections
+module.exports.ErrorList = ErrorList
 
 /**
  * Iterable Error type

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -30,26 +30,24 @@
  * await a.delay(1000)
  */
 
-module.exports = {
-  delay,
-  time,
-  limit,
-  event,
-  callback,
-  single,
-  set,
-  list,
-  object,
-  map,
-  failure,
-  success,
-  result,
-  awaited,
-  awaitable: awaited,
-  throw: throwRejections,
-  swallow: swallowRejections,
-  ErrorList
-}
+module.exports.delay = delay
+module.exports.time = time
+module.exports.limit = limit
+module.exports.event = event
+module.exports.callback = callback
+module.exports.single = single
+module.exports.set = set
+module.exports.list = list
+module.exports.object = object
+module.exports.map = map
+module.exports.failure = failure
+module.exports.success = success
+module.exports.result = result
+module.exports.awaited = awaited
+module.exports.awaitable = awaited
+module.exports.throw = throwRejections
+module.exports.swallow = swallowRejections
+module.exports.ErrorList = ErrorList
 
 /**
  * Iterable Error type
@@ -117,9 +115,7 @@ ErrorList.prototype[Symbol.iterator] = function* () {
  * // => 5000
  */
 async function delay (ms) {
-  return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms)
-  })
+  return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 /**
@@ -432,9 +428,10 @@ async function map (list, concurrency, fn) {
  * })
  */
 async function failure (promise) {
-  return new Promise((resolve, reject) => {
-    promise.then(() => resolve(undefined)).catch(resolve)
-  })
+  return Promise.resolve()
+    .then(() => promise)
+    .then(() => undefined)
+    .catch(err => err)
 }
 
 /**
@@ -449,9 +446,9 @@ async function failure (promise) {
  * if (isNodeProject) doSomething()
  */
 async function success (promise) {
-  return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(undefined)) // eslint-disable-line
-  })
+  return Promise.resolve()
+    .then(() => promise)
+    .catch(() => undefined) // eslint-disable-line
 }
 
 /**
@@ -467,9 +464,9 @@ async function success (promise) {
  * $("#ajax-loader-animation").hide();
  */
 async function result (promise) {
-  return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(err))
-  })
+  return Promise.resolve()
+    .then(() => promise)
+    .catch(err => err)
 }
 
 /**


### PR DESCRIPTION
I was able to solve #7 with this rollup config:

```js
import resolve from 'rollup-plugin-node-resolve'
import commonjs from 'rollup-plugin-commonjs'

export default {
  entry: 'index.js',
  dest: 'bundle.js',
  format: 'iife',
  plugins: [
    resolve(),
    commonjs()
  ]
}
```