### PR TITLE
write with es6 modules, use rollup to generate commonjs and umd

### DIFF
--- a/dist/awaiting.common.js
+++ b/dist/awaiting.common.js
@@ -1,3 +1,7 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
 /**
  * The async/await utility for browsers and Node.js.
  *
@@ -28,27 +32,6 @@
  * await a.delay(1000)
  */
 
-export {
-  delay,
-  time,
-  limit,
-  event,
-  callback,
-  single,
-  set,
-  list,
-  object,
-  map,
-  failure,
-  success,
-  result,
-  awaited,
-  awaited as awaitable,
-  throwRejections as throw,
-  swallowRejections as swallow,
-  ErrorList
-}
-
 /**
  * Iterable Error type
  *
@@ -78,29 +61,29 @@ export {
  * }
  */
 function ErrorList (message) {
-  this.name = 'ErrorList'
-  this.message = message
-  this.stack = (new Error()).stack
-  this.errors = []
+  this.name = 'ErrorList';
+  this.message = message;
+  this.stack = (new Error()).stack;
+  this.errors = [];
   Object.defineProperty(this, 'length', {
     get: function () { return this.errors.length }
-  })
+  });
 }
-ErrorList.prototype = Object.create(Error.prototype)
-ErrorList.prototype.constructor = ErrorList
+ErrorList.prototype = Object.create(Error.prototype);
+ErrorList.prototype.constructor = ErrorList;
 ErrorList.prototype.add = function (err) {
-  this.errors.push(err)
-}
+  this.errors.push(err);
+};
 ErrorList.prototype.get = function (index) {
   return this.errors[index]
-}
+};
 ErrorList.prototype[Symbol.iterator] = function* () {
-  let i = 0
+  let i = 0;
   while (i < this.errors.length) {
-    yield this.errors[i]
-    i++
+    yield this.errors[i];
+    i++;
   }
-}
+};
 
 /**
  * Waits for `ms` milliseconds to pass.
@@ -116,7 +99,7 @@ ErrorList.prototype[Symbol.iterator] = function* () {
  */
 async function delay (ms) {
   return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms)
+    setTimeout(resolve, ms);
   })
 }
 
@@ -132,7 +115,7 @@ async function delay (ms) {
  * // => this will run until the end of 2017
  */
 async function time (date) {
-  const delta = Math.max(date.getTime() - Date.now(), 0)
+  const delta = Math.max(date.getTime() - Date.now(), 0);
   return await delay(delta)
 }
 
@@ -153,29 +136,29 @@ async function limit (goal, limiter) {
   return new Promise((resolve, reject) => {
     const limitFn = typeof limiter === 'number'
       ? delay(limiter)
-      : limiter
-    let completed = false
+      : limiter;
+    let completed = false;
     goal
       .then(result => {
         if (complete()) return
-        resolve(result)
+        resolve(result);
       })
       .catch(err => {
         if (complete()) return
-        reject(err)
-      })
+        reject(err);
+      });
     limitFn
       .then(result => {
         if (complete()) return
-        reject(new Error('limit exceeded'))
+        reject(new Error('limit exceeded'));
       })
       .catch(err => {
         if (complete()) return
-        reject(err)
-      })
+        reject(err);
+      });
     function complete () {
       if (completed) return true
-      completed = true
+      completed = true;
       return false
     }
   })
@@ -194,8 +177,8 @@ async function limit (goal, limiter) {
 async function event (emitter, eventName) {
   return new Promise((resolve, reject) => {
     emitter.once(eventName, (...args) => {
-      resolve([...args])
-    })
+      resolve([...args]);
+    });
   })
 }
 
@@ -216,8 +199,8 @@ async function callback (fn, ...args) {
   return new Promise((resolve, reject) => {
     fn(...args, (err, result) => {
       if (err) return reject(err)
-      resolve(result)
-    })
+      resolve(result);
+    });
   })
 }
 
@@ -252,7 +235,7 @@ function swallowOnRejection (err, promise) {} // eslint-disable-line
  * const file = await a.single([ fetch(remoteFile), read(localFile) ])
  */
 async function single (list, ignore = 0) {
-  const results = await set(list, 1, ignore)
+  const results = await set(list, 1, ignore);
   return results[0]
 }
 
@@ -276,25 +259,25 @@ async function single (list, ignore = 0) {
 
 async function set (list, count = Infinity, ignore = 0) {
   return new Promise((resolve, reject) => {
-    const goal = Math.min(list.length, count)
-    const limit = Math.min(list.length - goal, ignore)
-    const results = []
-    const failures = new ErrorList('too many failures')
-    list.forEach(promise => promise.then(success).catch(error))
+    const goal = Math.min(list.length, count);
+    const limit = Math.min(list.length - goal, ignore);
+    const results = [];
+    const failures = new ErrorList('too many failures');
+    list.forEach(promise => promise.then(success).catch(error));
 
     function success (result) {
       if (failures.length > limit) return
-      results.push(result)
+      results.push(result);
       if (results.length === goal) {
-        resolve(results)
+        resolve(results);
       }
     }
     function error (err) {
       if (failures.length > limit) return
       if (results.length >= goal) return
-      failures.add(err)
+      failures.add(err);
       // TODO: reject with an Iterable custom Error that includes all failures
-      if (failures.length > limit) reject(failures)
+      if (failures.length > limit) reject(failures);
     }
   })
 }
@@ -315,27 +298,27 @@ async function set (list, count = Infinity, ignore = 0) {
  */
 async function list (list, ignore = 0) {
   return new Promise((resolve, reject) => {
-    const results = []
-    const failures = new ErrorList('too many failures')
-    const complete = () => count + failures.length === list.length
-    let count = 0
+    const results = [];
+    const failures = new ErrorList('too many failures');
+    const complete = () => count + failures.length === list.length;
+    let count = 0;
     list.forEach((promise, index) => {
-      promise.then(success).catch(error)
+      promise.then(success).catch(error);
 
       function success (result) {
         if (failures.length > ignore) return
-        results[index] = result
-        count++
-        if (complete()) resolve(results)
+        results[index] = result;
+        count++;
+        if (complete()) resolve(results);
       }
       function error (err) {
         if (failures.length > ignore) return
-        results[index] = undefined
-        failures.add(err)
-        if (failures.length > ignore) reject(failures)
-        else if (complete()) resolve(results)
+        results[index] = undefined;
+        failures.add(err);
+        if (failures.length > ignore) reject(failures);
+        else if (complete()) resolve(results);
       }
-    })
+    });
   })
 }
 
@@ -356,15 +339,15 @@ async function list (list, ignore = 0) {
  */
 
 async function object (container, ignore = 0) {
-  const containsPromise = key => typeof container[key].then === 'function'
-  const keys = Object.keys(container).filter(containsPromise)
-  const promises = keys.map(key => container[key])
-  const results = await list(promises, ignore)
-  const obj = Object.assign({}, container)
+  const containsPromise = key => typeof container[key].then === 'function';
+  const keys = Object.keys(container).filter(containsPromise);
+  const promises = keys.map(key => container[key]);
+  const results = await list(promises, ignore);
+  const obj = Object.assign({}, container);
   results.forEach((result, index) => {
-    const key = keys[index]
-    obj[key] = result
-  })
+    const key = keys[index];
+    obj[key] = result;
+  });
   return obj
 }
 
@@ -385,33 +368,33 @@ async function object (container, ignore = 0) {
  */
 async function map (list, concurrency, fn) {
   return new Promise((resolve, reject) => {
-    const results = []
-    let running = 0
-    let index = 0
+    const results = [];
+    let running = 0;
+    let index = 0;
 
-    update()
+    update();
 
     function update () {
       if (index === list.length && running === 0) {
         return resolve(results)
       }
       while (running < concurrency && index < list.length) {
-        fn(list[index]).then(success(index)).catch(error)
-        index++
-        running++
+        fn(list[index]).then(success(index)).catch(error);
+        index++;
+        running++;
       }
     }
     function success (i) {
       return result => {
-        running--
-        results[i] = result
-        update()
+        running--;
+        results[i] = result;
+        update();
       }
     }
     function error (err) {
-      running--
-      index = Infinity
-      reject(err)
+      running--;
+      index = Infinity;
+      reject(err);
     }
   })
 }
@@ -431,7 +414,7 @@ async function map (list, concurrency, fn) {
  */
 async function failure (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(() => resolve(undefined)).catch(resolve)
+    promise.then(() => resolve(undefined)).catch(resolve);
   })
 }
 
@@ -448,7 +431,7 @@ async function failure (promise) {
  */
 async function success (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(undefined)) // eslint-disable-line
+    promise.then(resolve).catch(err => resolve(undefined)); // eslint-disable-line
   })
 }
 
@@ -466,7 +449,7 @@ async function success (promise) {
  */
 async function result (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(err))
+    promise.then(resolve).catch(err => resolve(err));
   })
 }
 
@@ -494,9 +477,9 @@ async function result (promise) {
  * // =>    at Object.<anonymous> (/Users/hloftis/code/awaiting/test/fixtures/rejection-throw.js:4:1)
  */
 function throwRejections () {
-  process.removeListener('unhandledRejection', throwOnRejection)
-  process.removeListener('unhandledRejection', swallowOnRejection)
-  process.on('unhandledRejection', throwOnRejection)
+  process.removeListener('unhandledRejection', throwOnRejection);
+  process.removeListener('unhandledRejection', swallowOnRejection);
+  process.on('unhandledRejection', throwOnRejection);
 }
 
 /**
@@ -522,7 +505,26 @@ function throwRejections () {
  * // (no output)
  */
 function swallowRejections () {
-  process.removeListener('unhandledRejection', throwOnRejection)
-  process.removeListener('unhandledRejection', swallowOnRejection)
-  process.on('unhandledRejection', swallowOnRejection)
+  process.removeListener('unhandledRejection', throwOnRejection);
+  process.removeListener('unhandledRejection', swallowOnRejection);
+  process.on('unhandledRejection', swallowOnRejection);
 }
+
+exports.delay = delay;
+exports.time = time;
+exports.limit = limit;
+exports.event = event;
+exports.callback = callback;
+exports.single = single;
+exports.set = set;
+exports.list = list;
+exports.object = object;
+exports.map = map;
+exports.failure = failure;
+exports.success = success;
+exports.result = result;
+exports.awaited = awaited;
+exports.awaitable = awaited;
+exports.throw = throwRejections;
+exports.swallow = swallowRejections;
+exports.ErrorList = ErrorList;

--- a/dist/awaiting.umd.js
+++ b/dist/awaiting.umd.js
@@ -1,5 +1,9 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.awaiting = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-(function (process){
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.awaiting = global.awaiting || {})));
+}(this, (function (exports) { 'use strict';
+
 /**
  * The async/await utility for browsers and Node.js.
  *
@@ -30,27 +34,6 @@
  * await a.delay(1000)
  */
 
-module.exports = {
-  delay,
-  time,
-  limit,
-  event,
-  callback,
-  single,
-  set,
-  list,
-  object,
-  map,
-  failure,
-  success,
-  result,
-  awaited,
-  awaitable: awaited,
-  throw: throwRejections,
-  swallow: swallowRejections,
-  ErrorList
-}
-
 /**
  * Iterable Error type
  *
@@ -80,29 +63,29 @@ module.exports = {
  * }
  */
 function ErrorList (message) {
-  this.name = 'ErrorList'
-  this.message = message
-  this.stack = (new Error()).stack
-  this.errors = []
+  this.name = 'ErrorList';
+  this.message = message;
+  this.stack = (new Error()).stack;
+  this.errors = [];
   Object.defineProperty(this, 'length', {
     get: function () { return this.errors.length }
-  })
+  });
 }
-ErrorList.prototype = Object.create(Error.prototype)
-ErrorList.prototype.constructor = ErrorList
+ErrorList.prototype = Object.create(Error.prototype);
+ErrorList.prototype.constructor = ErrorList;
 ErrorList.prototype.add = function (err) {
-  this.errors.push(err)
-}
+  this.errors.push(err);
+};
 ErrorList.prototype.get = function (index) {
   return this.errors[index]
-}
+};
 ErrorList.prototype[Symbol.iterator] = function* () {
-  let i = 0
+  let i = 0;
   while (i < this.errors.length) {
-    yield this.errors[i]
-    i++
+    yield this.errors[i];
+    i++;
   }
-}
+};
 
 /**
  * Waits for `ms` milliseconds to pass.
@@ -118,7 +101,7 @@ ErrorList.prototype[Symbol.iterator] = function* () {
  */
 async function delay (ms) {
   return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms)
+    setTimeout(resolve, ms);
   })
 }
 
@@ -134,7 +117,7 @@ async function delay (ms) {
  * // => this will run until the end of 2017
  */
 async function time (date) {
-  const delta = Math.max(date.getTime() - Date.now(), 0)
+  const delta = Math.max(date.getTime() - Date.now(), 0);
   return await delay(delta)
 }
 
@@ -155,29 +138,29 @@ async function limit (goal, limiter) {
   return new Promise((resolve, reject) => {
     const limitFn = typeof limiter === 'number'
       ? delay(limiter)
-      : limiter
-    let completed = false
+      : limiter;
+    let completed = false;
     goal
       .then(result => {
         if (complete()) return
-        resolve(result)
+        resolve(result);
       })
       .catch(err => {
         if (complete()) return
-        reject(err)
-      })
+        reject(err);
+      });
     limitFn
       .then(result => {
         if (complete()) return
-        reject(new Error('limit exceeded'))
+        reject(new Error('limit exceeded'));
       })
       .catch(err => {
         if (complete()) return
-        reject(err)
-      })
+        reject(err);
+      });
     function complete () {
       if (completed) return true
-      completed = true
+      completed = true;
       return false
     }
   })
@@ -196,8 +179,8 @@ async function limit (goal, limiter) {
 async function event (emitter, eventName) {
   return new Promise((resolve, reject) => {
     emitter.once(eventName, (...args) => {
-      resolve([...args])
-    })
+      resolve([...args]);
+    });
   })
 }
 
@@ -218,8 +201,8 @@ async function callback (fn, ...args) {
   return new Promise((resolve, reject) => {
     fn(...args, (err, result) => {
       if (err) return reject(err)
-      resolve(result)
-    })
+      resolve(result);
+    });
   })
 }
 
@@ -254,7 +237,7 @@ function swallowOnRejection (err, promise) {} // eslint-disable-line
  * const file = await a.single([ fetch(remoteFile), read(localFile) ])
  */
 async function single (list, ignore = 0) {
-  const results = await set(list, 1, ignore)
+  const results = await set(list, 1, ignore);
   return results[0]
 }
 
@@ -278,25 +261,25 @@ async function single (list, ignore = 0) {
 
 async function set (list, count = Infinity, ignore = 0) {
   return new Promise((resolve, reject) => {
-    const goal = Math.min(list.length, count)
-    const limit = Math.min(list.length - goal, ignore)
-    const results = []
-    const failures = new ErrorList('too many failures')
-    list.forEach(promise => promise.then(success).catch(error))
+    const goal = Math.min(list.length, count);
+    const limit = Math.min(list.length - goal, ignore);
+    const results = [];
+    const failures = new ErrorList('too many failures');
+    list.forEach(promise => promise.then(success).catch(error));
 
     function success (result) {
       if (failures.length > limit) return
-      results.push(result)
+      results.push(result);
       if (results.length === goal) {
-        resolve(results)
+        resolve(results);
       }
     }
     function error (err) {
       if (failures.length > limit) return
       if (results.length >= goal) return
-      failures.add(err)
+      failures.add(err);
       // TODO: reject with an Iterable custom Error that includes all failures
-      if (failures.length > limit) reject(failures)
+      if (failures.length > limit) reject(failures);
     }
   })
 }
@@ -317,27 +300,27 @@ async function set (list, count = Infinity, ignore = 0) {
  */
 async function list (list, ignore = 0) {
   return new Promise((resolve, reject) => {
-    const results = []
-    const failures = new ErrorList('too many failures')
-    const complete = () => count + failures.length === list.length
-    let count = 0
+    const results = [];
+    const failures = new ErrorList('too many failures');
+    const complete = () => count + failures.length === list.length;
+    let count = 0;
     list.forEach((promise, index) => {
-      promise.then(success).catch(error)
+      promise.then(success).catch(error);
 
       function success (result) {
         if (failures.length > ignore) return
-        results[index] = result
-        count++
-        if (complete()) resolve(results)
+        results[index] = result;
+        count++;
+        if (complete()) resolve(results);
       }
       function error (err) {
         if (failures.length > ignore) return
-        results[index] = undefined
-        failures.add(err)
-        if (failures.length > ignore) reject(failures)
-        else if (complete()) resolve(results)
+        results[index] = undefined;
+        failures.add(err);
+        if (failures.length > ignore) reject(failures);
+        else if (complete()) resolve(results);
       }
-    })
+    });
   })
 }
 
@@ -358,15 +341,15 @@ async function list (list, ignore = 0) {
  */
 
 async function object (container, ignore = 0) {
-  const containsPromise = key => typeof container[key].then === 'function'
-  const keys = Object.keys(container).filter(containsPromise)
-  const promises = keys.map(key => container[key])
-  const results = await list(promises, ignore)
-  const obj = Object.assign({}, container)
+  const containsPromise = key => typeof container[key].then === 'function';
+  const keys = Object.keys(container).filter(containsPromise);
+  const promises = keys.map(key => container[key]);
+  const results = await list(promises, ignore);
+  const obj = Object.assign({}, container);
   results.forEach((result, index) => {
-    const key = keys[index]
-    obj[key] = result
-  })
+    const key = keys[index];
+    obj[key] = result;
+  });
   return obj
 }
 
@@ -387,33 +370,33 @@ async function object (container, ignore = 0) {
  */
 async function map (list, concurrency, fn) {
   return new Promise((resolve, reject) => {
-    const results = []
-    let running = 0
-    let index = 0
+    const results = [];
+    let running = 0;
+    let index = 0;
 
-    update()
+    update();
 
     function update () {
       if (index === list.length && running === 0) {
         return resolve(results)
       }
       while (running < concurrency && index < list.length) {
-        fn(list[index]).then(success(index)).catch(error)
-        index++
-        running++
+        fn(list[index]).then(success(index)).catch(error);
+        index++;
+        running++;
       }
     }
     function success (i) {
       return result => {
-        running--
-        results[i] = result
-        update()
+        running--;
+        results[i] = result;
+        update();
       }
     }
     function error (err) {
-      running--
-      index = Infinity
-      reject(err)
+      running--;
+      index = Infinity;
+      reject(err);
     }
   })
 }
@@ -433,7 +416,7 @@ async function map (list, concurrency, fn) {
  */
 async function failure (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(() => resolve(undefined)).catch(resolve)
+    promise.then(() => resolve(undefined)).catch(resolve);
   })
 }
 
@@ -450,7 +433,7 @@ async function failure (promise) {
  */
 async function success (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(undefined)) // eslint-disable-line
+    promise.then(resolve).catch(err => resolve(undefined)); // eslint-disable-line
   })
 }
 
@@ -468,7 +451,7 @@ async function success (promise) {
  */
 async function result (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(err))
+    promise.then(resolve).catch(err => resolve(err));
   })
 }
 
@@ -496,9 +479,9 @@ async function result (promise) {
  * // =>    at Object.<anonymous> (/Users/hloftis/code/awaiting/test/fixtures/rejection-throw.js:4:1)
  */
 function throwRejections () {
-  process.removeListener('unhandledRejection', throwOnRejection)
-  process.removeListener('unhandledRejection', swallowOnRejection)
-  process.on('unhandledRejection', throwOnRejection)
+  process.removeListener('unhandledRejection', throwOnRejection);
+  process.removeListener('unhandledRejection', swallowOnRejection);
+  process.on('unhandledRejection', throwOnRejection);
 }
 
 /**
@@ -524,193 +507,30 @@ function throwRejections () {
  * // (no output)
  */
 function swallowRejections () {
-  process.removeListener('unhandledRejection', throwOnRejection)
-  process.removeListener('unhandledRejection', swallowOnRejection)
-  process.on('unhandledRejection', swallowOnRejection)
+  process.removeListener('unhandledRejection', throwOnRejection);
+  process.removeListener('unhandledRejection', swallowOnRejection);
+  process.on('unhandledRejection', swallowOnRejection);
 }
 
-}).call(this,require('_process'))
-},{"_process":2}],2:[function(require,module,exports){
-// shim for using process in browser
-var process = module.exports = {};
+exports.delay = delay;
+exports.time = time;
+exports.limit = limit;
+exports.event = event;
+exports.callback = callback;
+exports.single = single;
+exports.set = set;
+exports.list = list;
+exports.object = object;
+exports.map = map;
+exports.failure = failure;
+exports.success = success;
+exports.result = result;
+exports.awaited = awaited;
+exports.awaitable = awaited;
+exports.throw = throwRejections;
+exports.swallow = swallowRejections;
+exports.ErrorList = ErrorList;
 
-// cached from whatever global is present so that test runners that stub it
-// don't break things.  But we need to wrap it in a try catch in case it is
-// wrapped in strict mode code which doesn't define any globals.  It's inside a
-// function because try/catches deoptimize in certain engines.
+Object.defineProperty(exports, '__esModule', { value: true });
 
-var cachedSetTimeout;
-var cachedClearTimeout;
-
-function defaultSetTimout() {
-    throw new Error('setTimeout has not been defined');
-}
-function defaultClearTimeout () {
-    throw new Error('clearTimeout has not been defined');
-}
-(function () {
-    try {
-        if (typeof setTimeout === 'function') {
-            cachedSetTimeout = setTimeout;
-        } else {
-            cachedSetTimeout = defaultSetTimout;
-        }
-    } catch (e) {
-        cachedSetTimeout = defaultSetTimout;
-    }
-    try {
-        if (typeof clearTimeout === 'function') {
-            cachedClearTimeout = clearTimeout;
-        } else {
-            cachedClearTimeout = defaultClearTimeout;
-        }
-    } catch (e) {
-        cachedClearTimeout = defaultClearTimeout;
-    }
-} ())
-function runTimeout(fun) {
-    if (cachedSetTimeout === setTimeout) {
-        //normal enviroments in sane situations
-        return setTimeout(fun, 0);
-    }
-    // if setTimeout wasn't available but was latter defined
-    if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
-        cachedSetTimeout = setTimeout;
-        return setTimeout(fun, 0);
-    }
-    try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
-        return cachedSetTimeout(fun, 0);
-    } catch(e){
-        try {
-            // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
-            return cachedSetTimeout.call(null, fun, 0);
-        } catch(e){
-            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
-            return cachedSetTimeout.call(this, fun, 0);
-        }
-    }
-
-
-}
-function runClearTimeout(marker) {
-    if (cachedClearTimeout === clearTimeout) {
-        //normal enviroments in sane situations
-        return clearTimeout(marker);
-    }
-    // if clearTimeout wasn't available but was latter defined
-    if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
-        cachedClearTimeout = clearTimeout;
-        return clearTimeout(marker);
-    }
-    try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
-        return cachedClearTimeout(marker);
-    } catch (e){
-        try {
-            // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
-            return cachedClearTimeout.call(null, marker);
-        } catch (e){
-            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
-            // Some versions of I.E. have different rules for clearTimeout vs setTimeout
-            return cachedClearTimeout.call(this, marker);
-        }
-    }
-
-
-
-}
-var queue = [];
-var draining = false;
-var currentQueue;
-var queueIndex = -1;
-
-function cleanUpNextTick() {
-    if (!draining || !currentQueue) {
-        return;
-    }
-    draining = false;
-    if (currentQueue.length) {
-        queue = currentQueue.concat(queue);
-    } else {
-        queueIndex = -1;
-    }
-    if (queue.length) {
-        drainQueue();
-    }
-}
-
-function drainQueue() {
-    if (draining) {
-        return;
-    }
-    var timeout = runTimeout(cleanUpNextTick);
-    draining = true;
-
-    var len = queue.length;
-    while(len) {
-        currentQueue = queue;
-        queue = [];
-        while (++queueIndex < len) {
-            if (currentQueue) {
-                currentQueue[queueIndex].run();
-            }
-        }
-        queueIndex = -1;
-        len = queue.length;
-    }
-    currentQueue = null;
-    draining = false;
-    runClearTimeout(timeout);
-}
-
-process.nextTick = function (fun) {
-    var args = new Array(arguments.length - 1);
-    if (arguments.length > 1) {
-        for (var i = 1; i < arguments.length; i++) {
-            args[i - 1] = arguments[i];
-        }
-    }
-    queue.push(new Item(fun, args));
-    if (queue.length === 1 && !draining) {
-        runTimeout(drainQueue);
-    }
-};
-
-// v8 likes predictible objects
-function Item(fun, array) {
-    this.fun = fun;
-    this.array = array;
-}
-Item.prototype.run = function () {
-    this.fun.apply(null, this.array);
-};
-process.title = 'browser';
-process.browser = true;
-process.env = {};
-process.argv = [];
-process.version = ''; // empty string to avoid regexp issues
-process.versions = {};
-
-function noop() {}
-
-process.on = noop;
-process.addListener = noop;
-process.once = noop;
-process.off = noop;
-process.removeListener = noop;
-process.removeAllListeners = noop;
-process.emit = noop;
-
-process.binding = function (name) {
-    throw new Error('process.binding is not supported');
-};
-
-process.cwd = function () { return '/' };
-process.chdir = function (dir) {
-    throw new Error('process.chdir is not supported');
-};
-process.umask = function() { return 0; };
-
-},{}]},{},[1])(1)
-});
+})));

--- a/docs/examples/awaiting.umd.js
+++ b/docs/examples/awaiting.umd.js
@@ -1,3 +1,9 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.awaiting = global.awaiting || {})));
+}(this, (function (exports) { 'use strict';
+
 /**
  * The async/await utility for browsers and Node.js.
  *
@@ -28,27 +34,6 @@
  * await a.delay(1000)
  */
 
-export {
-  delay,
-  time,
-  limit,
-  event,
-  callback,
-  single,
-  set,
-  list,
-  object,
-  map,
-  failure,
-  success,
-  result,
-  awaited,
-  awaited as awaitable,
-  throwRejections as throw,
-  swallowRejections as swallow,
-  ErrorList
-}
-
 /**
  * Iterable Error type
  *
@@ -78,29 +63,29 @@ export {
  * }
  */
 function ErrorList (message) {
-  this.name = 'ErrorList'
-  this.message = message
-  this.stack = (new Error()).stack
-  this.errors = []
+  this.name = 'ErrorList';
+  this.message = message;
+  this.stack = (new Error()).stack;
+  this.errors = [];
   Object.defineProperty(this, 'length', {
     get: function () { return this.errors.length }
-  })
+  });
 }
-ErrorList.prototype = Object.create(Error.prototype)
-ErrorList.prototype.constructor = ErrorList
+ErrorList.prototype = Object.create(Error.prototype);
+ErrorList.prototype.constructor = ErrorList;
 ErrorList.prototype.add = function (err) {
-  this.errors.push(err)
-}
+  this.errors.push(err);
+};
 ErrorList.prototype.get = function (index) {
   return this.errors[index]
-}
+};
 ErrorList.prototype[Symbol.iterator] = function* () {
-  let i = 0
+  let i = 0;
   while (i < this.errors.length) {
-    yield this.errors[i]
-    i++
+    yield this.errors[i];
+    i++;
   }
-}
+};
 
 /**
  * Waits for `ms` milliseconds to pass.
@@ -116,7 +101,7 @@ ErrorList.prototype[Symbol.iterator] = function* () {
  */
 async function delay (ms) {
   return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms)
+    setTimeout(resolve, ms);
   })
 }
 
@@ -132,7 +117,7 @@ async function delay (ms) {
  * // => this will run until the end of 2017
  */
 async function time (date) {
-  const delta = Math.max(date.getTime() - Date.now(), 0)
+  const delta = Math.max(date.getTime() - Date.now(), 0);
   return await delay(delta)
 }
 
@@ -153,29 +138,29 @@ async function limit (goal, limiter) {
   return new Promise((resolve, reject) => {
     const limitFn = typeof limiter === 'number'
       ? delay(limiter)
-      : limiter
-    let completed = false
+      : limiter;
+    let completed = false;
     goal
       .then(result => {
         if (complete()) return
-        resolve(result)
+        resolve(result);
       })
       .catch(err => {
         if (complete()) return
-        reject(err)
-      })
+        reject(err);
+      });
     limitFn
       .then(result => {
         if (complete()) return
-        reject(new Error('limit exceeded'))
+        reject(new Error('limit exceeded'));
       })
       .catch(err => {
         if (complete()) return
-        reject(err)
-      })
+        reject(err);
+      });
     function complete () {
       if (completed) return true
-      completed = true
+      completed = true;
       return false
     }
   })
@@ -194,8 +179,8 @@ async function limit (goal, limiter) {
 async function event (emitter, eventName) {
   return new Promise((resolve, reject) => {
     emitter.once(eventName, (...args) => {
-      resolve([...args])
-    })
+      resolve([...args]);
+    });
   })
 }
 
@@ -216,8 +201,8 @@ async function callback (fn, ...args) {
   return new Promise((resolve, reject) => {
     fn(...args, (err, result) => {
       if (err) return reject(err)
-      resolve(result)
-    })
+      resolve(result);
+    });
   })
 }
 
@@ -252,7 +237,7 @@ function swallowOnRejection (err, promise) {} // eslint-disable-line
  * const file = await a.single([ fetch(remoteFile), read(localFile) ])
  */
 async function single (list, ignore = 0) {
-  const results = await set(list, 1, ignore)
+  const results = await set(list, 1, ignore);
   return results[0]
 }
 
@@ -276,25 +261,25 @@ async function single (list, ignore = 0) {
 
 async function set (list, count = Infinity, ignore = 0) {
   return new Promise((resolve, reject) => {
-    const goal = Math.min(list.length, count)
-    const limit = Math.min(list.length - goal, ignore)
-    const results = []
-    const failures = new ErrorList('too many failures')
-    list.forEach(promise => promise.then(success).catch(error))
+    const goal = Math.min(list.length, count);
+    const limit = Math.min(list.length - goal, ignore);
+    const results = [];
+    const failures = new ErrorList('too many failures');
+    list.forEach(promise => promise.then(success).catch(error));
 
     function success (result) {
       if (failures.length > limit) return
-      results.push(result)
+      results.push(result);
       if (results.length === goal) {
-        resolve(results)
+        resolve(results);
       }
     }
     function error (err) {
       if (failures.length > limit) return
       if (results.length >= goal) return
-      failures.add(err)
+      failures.add(err);
       // TODO: reject with an Iterable custom Error that includes all failures
-      if (failures.length > limit) reject(failures)
+      if (failures.length > limit) reject(failures);
     }
   })
 }
@@ -315,27 +300,27 @@ async function set (list, count = Infinity, ignore = 0) {
  */
 async function list (list, ignore = 0) {
   return new Promise((resolve, reject) => {
-    const results = []
-    const failures = new ErrorList('too many failures')
-    const complete = () => count + failures.length === list.length
-    let count = 0
+    const results = [];
+    const failures = new ErrorList('too many failures');
+    const complete = () => count + failures.length === list.length;
+    let count = 0;
     list.forEach((promise, index) => {
-      promise.then(success).catch(error)
+      promise.then(success).catch(error);
 
       function success (result) {
         if (failures.length > ignore) return
-        results[index] = result
-        count++
-        if (complete()) resolve(results)
+        results[index] = result;
+        count++;
+        if (complete()) resolve(results);
       }
       function error (err) {
         if (failures.length > ignore) return
-        results[index] = undefined
-        failures.add(err)
-        if (failures.length > ignore) reject(failures)
-        else if (complete()) resolve(results)
+        results[index] = undefined;
+        failures.add(err);
+        if (failures.length > ignore) reject(failures);
+        else if (complete()) resolve(results);
       }
-    })
+    });
   })
 }
 
@@ -356,15 +341,15 @@ async function list (list, ignore = 0) {
  */
 
 async function object (container, ignore = 0) {
-  const containsPromise = key => typeof container[key].then === 'function'
-  const keys = Object.keys(container).filter(containsPromise)
-  const promises = keys.map(key => container[key])
-  const results = await list(promises, ignore)
-  const obj = Object.assign({}, container)
+  const containsPromise = key => typeof container[key].then === 'function';
+  const keys = Object.keys(container).filter(containsPromise);
+  const promises = keys.map(key => container[key]);
+  const results = await list(promises, ignore);
+  const obj = Object.assign({}, container);
   results.forEach((result, index) => {
-    const key = keys[index]
-    obj[key] = result
-  })
+    const key = keys[index];
+    obj[key] = result;
+  });
   return obj
 }
 
@@ -385,33 +370,33 @@ async function object (container, ignore = 0) {
  */
 async function map (list, concurrency, fn) {
   return new Promise((resolve, reject) => {
-    const results = []
-    let running = 0
-    let index = 0
+    const results = [];
+    let running = 0;
+    let index = 0;
 
-    update()
+    update();
 
     function update () {
       if (index === list.length && running === 0) {
         return resolve(results)
       }
       while (running < concurrency && index < list.length) {
-        fn(list[index]).then(success(index)).catch(error)
-        index++
-        running++
+        fn(list[index]).then(success(index)).catch(error);
+        index++;
+        running++;
       }
     }
     function success (i) {
       return result => {
-        running--
-        results[i] = result
-        update()
+        running--;
+        results[i] = result;
+        update();
       }
     }
     function error (err) {
-      running--
-      index = Infinity
-      reject(err)
+      running--;
+      index = Infinity;
+      reject(err);
     }
   })
 }
@@ -431,7 +416,7 @@ async function map (list, concurrency, fn) {
  */
 async function failure (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(() => resolve(undefined)).catch(resolve)
+    promise.then(() => resolve(undefined)).catch(resolve);
   })
 }
 
@@ -448,7 +433,7 @@ async function failure (promise) {
  */
 async function success (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(undefined)) // eslint-disable-line
+    promise.then(resolve).catch(err => resolve(undefined)); // eslint-disable-line
   })
 }
 
@@ -466,7 +451,7 @@ async function success (promise) {
  */
 async function result (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(err))
+    promise.then(resolve).catch(err => resolve(err));
   })
 }
 
@@ -494,9 +479,9 @@ async function result (promise) {
  * // =>    at Object.<anonymous> (/Users/hloftis/code/awaiting/test/fixtures/rejection-throw.js:4:1)
  */
 function throwRejections () {
-  process.removeListener('unhandledRejection', throwOnRejection)
-  process.removeListener('unhandledRejection', swallowOnRejection)
-  process.on('unhandledRejection', throwOnRejection)
+  process.removeListener('unhandledRejection', throwOnRejection);
+  process.removeListener('unhandledRejection', swallowOnRejection);
+  process.on('unhandledRejection', throwOnRejection);
 }
 
 /**
@@ -522,7 +507,30 @@ function throwRejections () {
  * // (no output)
  */
 function swallowRejections () {
-  process.removeListener('unhandledRejection', throwOnRejection)
-  process.removeListener('unhandledRejection', swallowOnRejection)
-  process.on('unhandledRejection', swallowOnRejection)
+  process.removeListener('unhandledRejection', throwOnRejection);
+  process.removeListener('unhandledRejection', swallowOnRejection);
+  process.on('unhandledRejection', swallowOnRejection);
 }
+
+exports.delay = delay;
+exports.time = time;
+exports.limit = limit;
+exports.event = event;
+exports.callback = callback;
+exports.single = single;
+exports.set = set;
+exports.list = list;
+exports.object = object;
+exports.map = map;
+exports.failure = failure;
+exports.success = success;
+exports.result = result;
+exports.awaited = awaited;
+exports.awaitable = awaited;
+exports.throw = throwRejections;
+exports.swallow = swallowRejections;
+exports.ErrorList = ErrorList;
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/docs/examples/kittens.html
+++ b/docs/examples/kittens.html
@@ -3,7 +3,7 @@
 <head>
 </head>
 <body>
-  <script src='awaiting.js'></script>
+  <script src='awaiting.umd.js'></script>
   <script>
     const a = awaiting
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,9 +25,9 @@
               
                 
                 <li><a
-                  href='#awaiting'
+                  href='#errorlist'
                   class="">
-                  awaiting
+                  ErrorList
                   
                 </a>
                 
@@ -218,13 +218,13 @@
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='awaiting'>
-      awaiting
+    <h3 class='fl m0' id='errorlist'>
+      ErrorList
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L31-L50'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L63-L71'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -246,7 +246,7 @@
 <a href="https://coveralls.io/r/hunterloftis/awaiting?branch=master"><img src="https://coveralls.io/repos/hunterloftis/awaiting/badge.svg?branch=master" alt="Coverage Status"></a></p>
 
 
-  <div class='pre p1 fill-light mt0'>awaiting</div>
+  <div class='pre p1 fill-light mt0'>ErrorList</div>
   
   
 
@@ -256,6 +256,19 @@
   
   
 
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>message</span> <code class='quiet'>(any)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
   
 
   
@@ -294,8 +307,8 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L80-L88'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L63-L71'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -388,8 +401,8 @@ err.add(<span class="hljs-keyword">new</span> <span class="hljs-built_in">Error<
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L117-L121'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L100-L104'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -469,8 +482,8 @@ err.add(<span class="hljs-keyword">new</span> <span class="hljs-built_in">Error<
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L134-L137'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L117-L120'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -549,8 +562,8 @@ err.add(<span class="hljs-keyword">new</span> <span class="hljs-built_in">Error<
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L152-L182'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L135-L165'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -639,8 +652,8 @@ If <code>limiter</code> is a number, limits by time in milliseconds</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L194-L200'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L177-L183'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -728,8 +741,8 @@ If <code>limiter</code> is a number, limits by time in milliseconds</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L215-L222'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L198-L205'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -819,8 +832,8 @@ Waits for the callback result, throwing an Error if err is truthy.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L237-L239'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L220-L222'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -901,8 +914,8 @@ arguments as the original function <code>fn</code>.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L254-L257'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L237-L240'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -989,8 +1002,8 @@ arguments as the original function <code>fn</code>.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L277-L300'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L260-L283'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -1093,8 +1106,8 @@ arguments as the original function <code>fn</code>.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L316-L340'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L299-L323'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -1183,8 +1196,8 @@ arguments as the original function <code>fn</code>.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L358-L369'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L341-L352'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -1274,8 +1287,8 @@ arguments as the original function <code>fn</code>.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L386-L417'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L369-L400'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -1366,8 +1379,8 @@ such as making a large number of requests to a server with rate-limiting.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L432-L436'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L415-L419'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -1447,8 +1460,8 @@ If <code>promise</code> resolves successfully, returns <code>undefined</code>.</
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L449-L453'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L432-L436'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -1526,8 +1539,8 @@ If <code>promise</code> throws an Error, returns <code>undefined</code>.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L467-L471'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L450-L454'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -1606,8 +1619,8 @@ $(<span class="hljs-string">"#ajax-loader-animation"</span>).hide();</pre>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L496-L500'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L479-L483'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>
@@ -1682,8 +1695,8 @@ failingPromise()
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/ead1d9f8cda94bfa2d1d6dff2052dd8573aaa134/lib/awaiting.js#L524-L528'>
-      <span>lib/awaiting.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/hunterloftis/awaiting/blob/63d9016af7f4ee6ca5f45a46fe9789add4d4cbe9/dist/awaiting.common.js#L507-L511'>
+      <span>dist/awaiting.common.js</span>
       </a>
     
   </div>

--- a/examples/awaiting.umd.js
+++ b/examples/awaiting.umd.js
@@ -1,5 +1,9 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.awaiting = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-(function (process){
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.awaiting = global.awaiting || {})));
+}(this, (function (exports) { 'use strict';
+
 /**
  * The async/await utility for browsers and Node.js.
  *
@@ -30,27 +34,6 @@
  * await a.delay(1000)
  */
 
-module.exports = {
-  delay,
-  time,
-  limit,
-  event,
-  callback,
-  single,
-  set,
-  list,
-  object,
-  map,
-  failure,
-  success,
-  result,
-  awaited,
-  awaitable: awaited,
-  throw: throwRejections,
-  swallow: swallowRejections,
-  ErrorList
-}
-
 /**
  * Iterable Error type
  *
@@ -80,29 +63,29 @@ module.exports = {
  * }
  */
 function ErrorList (message) {
-  this.name = 'ErrorList'
-  this.message = message
-  this.stack = (new Error()).stack
-  this.errors = []
+  this.name = 'ErrorList';
+  this.message = message;
+  this.stack = (new Error()).stack;
+  this.errors = [];
   Object.defineProperty(this, 'length', {
     get: function () { return this.errors.length }
-  })
+  });
 }
-ErrorList.prototype = Object.create(Error.prototype)
-ErrorList.prototype.constructor = ErrorList
+ErrorList.prototype = Object.create(Error.prototype);
+ErrorList.prototype.constructor = ErrorList;
 ErrorList.prototype.add = function (err) {
-  this.errors.push(err)
-}
+  this.errors.push(err);
+};
 ErrorList.prototype.get = function (index) {
   return this.errors[index]
-}
+};
 ErrorList.prototype[Symbol.iterator] = function* () {
-  let i = 0
+  let i = 0;
   while (i < this.errors.length) {
-    yield this.errors[i]
-    i++
+    yield this.errors[i];
+    i++;
   }
-}
+};
 
 /**
  * Waits for `ms` milliseconds to pass.
@@ -118,7 +101,7 @@ ErrorList.prototype[Symbol.iterator] = function* () {
  */
 async function delay (ms) {
   return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms)
+    setTimeout(resolve, ms);
   })
 }
 
@@ -134,7 +117,7 @@ async function delay (ms) {
  * // => this will run until the end of 2017
  */
 async function time (date) {
-  const delta = Math.max(date.getTime() - Date.now(), 0)
+  const delta = Math.max(date.getTime() - Date.now(), 0);
   return await delay(delta)
 }
 
@@ -155,29 +138,29 @@ async function limit (goal, limiter) {
   return new Promise((resolve, reject) => {
     const limitFn = typeof limiter === 'number'
       ? delay(limiter)
-      : limiter
-    let completed = false
+      : limiter;
+    let completed = false;
     goal
       .then(result => {
         if (complete()) return
-        resolve(result)
+        resolve(result);
       })
       .catch(err => {
         if (complete()) return
-        reject(err)
-      })
+        reject(err);
+      });
     limitFn
       .then(result => {
         if (complete()) return
-        reject(new Error('limit exceeded'))
+        reject(new Error('limit exceeded'));
       })
       .catch(err => {
         if (complete()) return
-        reject(err)
-      })
+        reject(err);
+      });
     function complete () {
       if (completed) return true
-      completed = true
+      completed = true;
       return false
     }
   })
@@ -196,8 +179,8 @@ async function limit (goal, limiter) {
 async function event (emitter, eventName) {
   return new Promise((resolve, reject) => {
     emitter.once(eventName, (...args) => {
-      resolve([...args])
-    })
+      resolve([...args]);
+    });
   })
 }
 
@@ -218,8 +201,8 @@ async function callback (fn, ...args) {
   return new Promise((resolve, reject) => {
     fn(...args, (err, result) => {
       if (err) return reject(err)
-      resolve(result)
-    })
+      resolve(result);
+    });
   })
 }
 
@@ -254,7 +237,7 @@ function swallowOnRejection (err, promise) {} // eslint-disable-line
  * const file = await a.single([ fetch(remoteFile), read(localFile) ])
  */
 async function single (list, ignore = 0) {
-  const results = await set(list, 1, ignore)
+  const results = await set(list, 1, ignore);
   return results[0]
 }
 
@@ -278,25 +261,25 @@ async function single (list, ignore = 0) {
 
 async function set (list, count = Infinity, ignore = 0) {
   return new Promise((resolve, reject) => {
-    const goal = Math.min(list.length, count)
-    const limit = Math.min(list.length - goal, ignore)
-    const results = []
-    const failures = new ErrorList('too many failures')
-    list.forEach(promise => promise.then(success).catch(error))
+    const goal = Math.min(list.length, count);
+    const limit = Math.min(list.length - goal, ignore);
+    const results = [];
+    const failures = new ErrorList('too many failures');
+    list.forEach(promise => promise.then(success).catch(error));
 
     function success (result) {
       if (failures.length > limit) return
-      results.push(result)
+      results.push(result);
       if (results.length === goal) {
-        resolve(results)
+        resolve(results);
       }
     }
     function error (err) {
       if (failures.length > limit) return
       if (results.length >= goal) return
-      failures.add(err)
+      failures.add(err);
       // TODO: reject with an Iterable custom Error that includes all failures
-      if (failures.length > limit) reject(failures)
+      if (failures.length > limit) reject(failures);
     }
   })
 }
@@ -317,27 +300,27 @@ async function set (list, count = Infinity, ignore = 0) {
  */
 async function list (list, ignore = 0) {
   return new Promise((resolve, reject) => {
-    const results = []
-    const failures = new ErrorList('too many failures')
-    const complete = () => count + failures.length === list.length
-    let count = 0
+    const results = [];
+    const failures = new ErrorList('too many failures');
+    const complete = () => count + failures.length === list.length;
+    let count = 0;
     list.forEach((promise, index) => {
-      promise.then(success).catch(error)
+      promise.then(success).catch(error);
 
       function success (result) {
         if (failures.length > ignore) return
-        results[index] = result
-        count++
-        if (complete()) resolve(results)
+        results[index] = result;
+        count++;
+        if (complete()) resolve(results);
       }
       function error (err) {
         if (failures.length > ignore) return
-        results[index] = undefined
-        failures.add(err)
-        if (failures.length > ignore) reject(failures)
-        else if (complete()) resolve(results)
+        results[index] = undefined;
+        failures.add(err);
+        if (failures.length > ignore) reject(failures);
+        else if (complete()) resolve(results);
       }
-    })
+    });
   })
 }
 
@@ -358,15 +341,15 @@ async function list (list, ignore = 0) {
  */
 
 async function object (container, ignore = 0) {
-  const containsPromise = key => typeof container[key].then === 'function'
-  const keys = Object.keys(container).filter(containsPromise)
-  const promises = keys.map(key => container[key])
-  const results = await list(promises, ignore)
-  const obj = Object.assign({}, container)
+  const containsPromise = key => typeof container[key].then === 'function';
+  const keys = Object.keys(container).filter(containsPromise);
+  const promises = keys.map(key => container[key]);
+  const results = await list(promises, ignore);
+  const obj = Object.assign({}, container);
   results.forEach((result, index) => {
-    const key = keys[index]
-    obj[key] = result
-  })
+    const key = keys[index];
+    obj[key] = result;
+  });
   return obj
 }
 
@@ -387,33 +370,33 @@ async function object (container, ignore = 0) {
  */
 async function map (list, concurrency, fn) {
   return new Promise((resolve, reject) => {
-    const results = []
-    let running = 0
-    let index = 0
+    const results = [];
+    let running = 0;
+    let index = 0;
 
-    update()
+    update();
 
     function update () {
       if (index === list.length && running === 0) {
         return resolve(results)
       }
       while (running < concurrency && index < list.length) {
-        fn(list[index]).then(success(index)).catch(error)
-        index++
-        running++
+        fn(list[index]).then(success(index)).catch(error);
+        index++;
+        running++;
       }
     }
     function success (i) {
       return result => {
-        running--
-        results[i] = result
-        update()
+        running--;
+        results[i] = result;
+        update();
       }
     }
     function error (err) {
-      running--
-      index = Infinity
-      reject(err)
+      running--;
+      index = Infinity;
+      reject(err);
     }
   })
 }
@@ -433,7 +416,7 @@ async function map (list, concurrency, fn) {
  */
 async function failure (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(() => resolve(undefined)).catch(resolve)
+    promise.then(() => resolve(undefined)).catch(resolve);
   })
 }
 
@@ -450,7 +433,7 @@ async function failure (promise) {
  */
 async function success (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(undefined)) // eslint-disable-line
+    promise.then(resolve).catch(err => resolve(undefined)); // eslint-disable-line
   })
 }
 
@@ -468,7 +451,7 @@ async function success (promise) {
  */
 async function result (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(err))
+    promise.then(resolve).catch(err => resolve(err));
   })
 }
 
@@ -496,9 +479,9 @@ async function result (promise) {
  * // =>    at Object.<anonymous> (/Users/hloftis/code/awaiting/test/fixtures/rejection-throw.js:4:1)
  */
 function throwRejections () {
-  process.removeListener('unhandledRejection', throwOnRejection)
-  process.removeListener('unhandledRejection', swallowOnRejection)
-  process.on('unhandledRejection', throwOnRejection)
+  process.removeListener('unhandledRejection', throwOnRejection);
+  process.removeListener('unhandledRejection', swallowOnRejection);
+  process.on('unhandledRejection', throwOnRejection);
 }
 
 /**
@@ -524,193 +507,30 @@ function throwRejections () {
  * // (no output)
  */
 function swallowRejections () {
-  process.removeListener('unhandledRejection', throwOnRejection)
-  process.removeListener('unhandledRejection', swallowOnRejection)
-  process.on('unhandledRejection', swallowOnRejection)
+  process.removeListener('unhandledRejection', throwOnRejection);
+  process.removeListener('unhandledRejection', swallowOnRejection);
+  process.on('unhandledRejection', swallowOnRejection);
 }
 
-}).call(this,require('_process'))
-},{"_process":2}],2:[function(require,module,exports){
-// shim for using process in browser
-var process = module.exports = {};
+exports.delay = delay;
+exports.time = time;
+exports.limit = limit;
+exports.event = event;
+exports.callback = callback;
+exports.single = single;
+exports.set = set;
+exports.list = list;
+exports.object = object;
+exports.map = map;
+exports.failure = failure;
+exports.success = success;
+exports.result = result;
+exports.awaited = awaited;
+exports.awaitable = awaited;
+exports.throw = throwRejections;
+exports.swallow = swallowRejections;
+exports.ErrorList = ErrorList;
 
-// cached from whatever global is present so that test runners that stub it
-// don't break things.  But we need to wrap it in a try catch in case it is
-// wrapped in strict mode code which doesn't define any globals.  It's inside a
-// function because try/catches deoptimize in certain engines.
+Object.defineProperty(exports, '__esModule', { value: true });
 
-var cachedSetTimeout;
-var cachedClearTimeout;
-
-function defaultSetTimout() {
-    throw new Error('setTimeout has not been defined');
-}
-function defaultClearTimeout () {
-    throw new Error('clearTimeout has not been defined');
-}
-(function () {
-    try {
-        if (typeof setTimeout === 'function') {
-            cachedSetTimeout = setTimeout;
-        } else {
-            cachedSetTimeout = defaultSetTimout;
-        }
-    } catch (e) {
-        cachedSetTimeout = defaultSetTimout;
-    }
-    try {
-        if (typeof clearTimeout === 'function') {
-            cachedClearTimeout = clearTimeout;
-        } else {
-            cachedClearTimeout = defaultClearTimeout;
-        }
-    } catch (e) {
-        cachedClearTimeout = defaultClearTimeout;
-    }
-} ())
-function runTimeout(fun) {
-    if (cachedSetTimeout === setTimeout) {
-        //normal enviroments in sane situations
-        return setTimeout(fun, 0);
-    }
-    // if setTimeout wasn't available but was latter defined
-    if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
-        cachedSetTimeout = setTimeout;
-        return setTimeout(fun, 0);
-    }
-    try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
-        return cachedSetTimeout(fun, 0);
-    } catch(e){
-        try {
-            // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
-            return cachedSetTimeout.call(null, fun, 0);
-        } catch(e){
-            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
-            return cachedSetTimeout.call(this, fun, 0);
-        }
-    }
-
-
-}
-function runClearTimeout(marker) {
-    if (cachedClearTimeout === clearTimeout) {
-        //normal enviroments in sane situations
-        return clearTimeout(marker);
-    }
-    // if clearTimeout wasn't available but was latter defined
-    if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
-        cachedClearTimeout = clearTimeout;
-        return clearTimeout(marker);
-    }
-    try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
-        return cachedClearTimeout(marker);
-    } catch (e){
-        try {
-            // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
-            return cachedClearTimeout.call(null, marker);
-        } catch (e){
-            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
-            // Some versions of I.E. have different rules for clearTimeout vs setTimeout
-            return cachedClearTimeout.call(this, marker);
-        }
-    }
-
-
-
-}
-var queue = [];
-var draining = false;
-var currentQueue;
-var queueIndex = -1;
-
-function cleanUpNextTick() {
-    if (!draining || !currentQueue) {
-        return;
-    }
-    draining = false;
-    if (currentQueue.length) {
-        queue = currentQueue.concat(queue);
-    } else {
-        queueIndex = -1;
-    }
-    if (queue.length) {
-        drainQueue();
-    }
-}
-
-function drainQueue() {
-    if (draining) {
-        return;
-    }
-    var timeout = runTimeout(cleanUpNextTick);
-    draining = true;
-
-    var len = queue.length;
-    while(len) {
-        currentQueue = queue;
-        queue = [];
-        while (++queueIndex < len) {
-            if (currentQueue) {
-                currentQueue[queueIndex].run();
-            }
-        }
-        queueIndex = -1;
-        len = queue.length;
-    }
-    currentQueue = null;
-    draining = false;
-    runClearTimeout(timeout);
-}
-
-process.nextTick = function (fun) {
-    var args = new Array(arguments.length - 1);
-    if (arguments.length > 1) {
-        for (var i = 1; i < arguments.length; i++) {
-            args[i - 1] = arguments[i];
-        }
-    }
-    queue.push(new Item(fun, args));
-    if (queue.length === 1 && !draining) {
-        runTimeout(drainQueue);
-    }
-};
-
-// v8 likes predictible objects
-function Item(fun, array) {
-    this.fun = fun;
-    this.array = array;
-}
-Item.prototype.run = function () {
-    this.fun.apply(null, this.array);
-};
-process.title = 'browser';
-process.browser = true;
-process.env = {};
-process.argv = [];
-process.version = ''; // empty string to avoid regexp issues
-process.versions = {};
-
-function noop() {}
-
-process.on = noop;
-process.addListener = noop;
-process.once = noop;
-process.off = noop;
-process.removeListener = noop;
-process.removeAllListeners = noop;
-process.emit = noop;
-
-process.binding = function (name) {
-    throw new Error('process.binding is not supported');
-};
-
-process.cwd = function () { return '/' };
-process.chdir = function (dir) {
-    throw new Error('process.chdir is not supported');
-};
-process.umask = function() { return 0; };
-
-},{}]},{},[1])(1)
-});
+})));

--- a/examples/kittens.html
+++ b/examples/kittens.html
@@ -3,7 +3,7 @@
 <head>
 </head>
 <body>
-  <script src='awaiting.js'></script>
+  <script src='awaiting.umd.js'></script>
   <script>
     const a = awaiting
 

--- a/package.json
+++ b/package.json
@@ -25,22 +25,22 @@
   "bugs": "https://github.com/hunterloftis/awaiting/issues",
   "scripts": {
     "lint": "standard --fix 'lib/**/*.js'",
-    "secure": "nsp check",
-    "test:spec": "nyc --check-coverage --lines 100 --functions 100 --branches 100 mocha --bail test/*.test.js test/node/*.test.js",
-    "test:browser": "yarn browserify:tests && open test/browser/index.html",
-    "test": "yarn lint && yarn secure && yarn test:spec",
+    "test": "yarn lint && yarn test:node",
+    "rollup:node": "rollup lib/awaiting.js --format cjs --output dist/awaiting.common.js",
+    "rollup:browser": "rollup lib/awaiting.js --format umd --name 'awaiting' --output dist/awaiting.umd.js",
+    "rollup": "yarn rollup:node && yarn rollup:browser",
+    "test:node": "yarn rollup:node && nyc --check-coverage --lines 100 --functions 100 --branches 100 mocha --bail test/*.test.js test/node/*.test.js",
+    "test:browser": "browserify test/*.test.js -o test/browser/test.js && open test/browser/index.html",
     "coverage:report": "nyc --reporter html mocha --bail test/*.test.js test/node/*.test.js && open coverage/index.html",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "browserify:lib": "browserify lib/awaiting.js --standalone awaiting -o browser/awaiting.js && cp browser/awaiting.js examples",
-    "browserify:tests": "browserify test/*.test.js -o test/browser/test.js",
-    "browserify": "yarn browserify:lib && yarn browserify:tests",
     "safe": "git diff-index --quiet master --",
-    "build": "yarn install && yarn test && yarn browserify",
+    "build": "yarn install && yarn test && yarn rollup",
     "release": "yarn safe && yarn version && npm publish --registry 'https://registry.npmjs.org/'",
-    "build:docs": "documentation build -f html -g -o docs && cp -r examples docs",
-    "release:docs": "yarn safe && git subtree push --prefix docs origin gh-pages"
+    "docs:build": "documentation build -f html -g -o docs && cp dist/awaiting.umd.js examples && cp -r examples docs",
+    "docs:release": "yarn safe && git subtree push --prefix docs origin gh-pages"
   },
-  "main": "lib/awaiting.js",
+  "main": "dist/awaiting.common.js",
+  "module": "dist/awaiting.es.js",
   "license": "MIT",
   "devDependencies": {
     "browserify": "^14.3.0",
@@ -49,9 +49,8 @@
     "documentation": "^4.0.0-beta.18",
     "markdown-to-html": "^0.0.13",
     "mocha": "^3.2.0",
-    "nodemon": "^1.11.0",
-    "nsp": "^2.6.2",
     "nyc": "^10.2.0",
+    "rollup": "^0.41.6",
     "standard": "^8.6.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ async function main() {
 
 ### In a browser
 
-Use [browser/awaiting.umd.js](https://raw.githubusercontent.com/hunterloftis/awaiting/master/dist/awaiting.umd.js):
+Use [dist/awaiting.umd.js](https://raw.githubusercontent.com/hunterloftis/awaiting/master/dist/awaiting.umd.js):
 
 ```html
 <script src='awaiting.js'></script>

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ async function main() {
 
 ### In a browser
 
-Use [browser/awaiting.js](https://raw.githubusercontent.com/hunterloftis/awaiting/master/browser/awaiting.js):
+Use [browser/awaiting.umd.js](https://raw.githubusercontent.com/hunterloftis/awaiting/master/dist/awaiting.umd.js):
 
 ```html
 <script src='awaiting.js'></script>
@@ -54,12 +54,16 @@ Use [browser/awaiting.js](https://raw.githubusercontent.com/hunterloftis/awaitin
   const a = awaiting
 
   main()
-  
+
   async function main() {
     await a.delay(1000)
   }
 </script>
 ```
+
+### With Babel
+
+`import` whatever you want, you hipster.
 
 ## Examples
 
@@ -176,5 +180,4 @@ $ yarn build
 $ yarn install
 $ yarn test
 $ yarn test:browser
-$ yarn coverage:report
 ```

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -1,5 +1,9 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 (function (process){
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
 /**
  * The async/await utility for browsers and Node.js.
  *
@@ -30,27 +34,6 @@
  * await a.delay(1000)
  */
 
-module.exports = {
-  delay,
-  time,
-  limit,
-  event,
-  callback,
-  single,
-  set,
-  list,
-  object,
-  map,
-  failure,
-  success,
-  result,
-  awaited,
-  awaitable: awaited,
-  throw: throwRejections,
-  swallow: swallowRejections,
-  ErrorList
-}
-
 /**
  * Iterable Error type
  *
@@ -80,29 +63,29 @@ module.exports = {
  * }
  */
 function ErrorList (message) {
-  this.name = 'ErrorList'
-  this.message = message
-  this.stack = (new Error()).stack
-  this.errors = []
+  this.name = 'ErrorList';
+  this.message = message;
+  this.stack = (new Error()).stack;
+  this.errors = [];
   Object.defineProperty(this, 'length', {
     get: function () { return this.errors.length }
-  })
+  });
 }
-ErrorList.prototype = Object.create(Error.prototype)
-ErrorList.prototype.constructor = ErrorList
+ErrorList.prototype = Object.create(Error.prototype);
+ErrorList.prototype.constructor = ErrorList;
 ErrorList.prototype.add = function (err) {
-  this.errors.push(err)
-}
+  this.errors.push(err);
+};
 ErrorList.prototype.get = function (index) {
   return this.errors[index]
-}
+};
 ErrorList.prototype[Symbol.iterator] = function* () {
-  let i = 0
+  let i = 0;
   while (i < this.errors.length) {
-    yield this.errors[i]
-    i++
+    yield this.errors[i];
+    i++;
   }
-}
+};
 
 /**
  * Waits for `ms` milliseconds to pass.
@@ -118,7 +101,7 @@ ErrorList.prototype[Symbol.iterator] = function* () {
  */
 async function delay (ms) {
   return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms)
+    setTimeout(resolve, ms);
   })
 }
 
@@ -134,7 +117,7 @@ async function delay (ms) {
  * // => this will run until the end of 2017
  */
 async function time (date) {
-  const delta = Math.max(date.getTime() - Date.now(), 0)
+  const delta = Math.max(date.getTime() - Date.now(), 0);
   return await delay(delta)
 }
 
@@ -155,29 +138,29 @@ async function limit (goal, limiter) {
   return new Promise((resolve, reject) => {
     const limitFn = typeof limiter === 'number'
       ? delay(limiter)
-      : limiter
-    let completed = false
+      : limiter;
+    let completed = false;
     goal
       .then(result => {
         if (complete()) return
-        resolve(result)
+        resolve(result);
       })
       .catch(err => {
         if (complete()) return
-        reject(err)
-      })
+        reject(err);
+      });
     limitFn
       .then(result => {
         if (complete()) return
-        reject(new Error('limit exceeded'))
+        reject(new Error('limit exceeded'));
       })
       .catch(err => {
         if (complete()) return
-        reject(err)
-      })
+        reject(err);
+      });
     function complete () {
       if (completed) return true
-      completed = true
+      completed = true;
       return false
     }
   })
@@ -196,8 +179,8 @@ async function limit (goal, limiter) {
 async function event (emitter, eventName) {
   return new Promise((resolve, reject) => {
     emitter.once(eventName, (...args) => {
-      resolve([...args])
-    })
+      resolve([...args]);
+    });
   })
 }
 
@@ -218,8 +201,8 @@ async function callback (fn, ...args) {
   return new Promise((resolve, reject) => {
     fn(...args, (err, result) => {
       if (err) return reject(err)
-      resolve(result)
-    })
+      resolve(result);
+    });
   })
 }
 
@@ -254,7 +237,7 @@ function swallowOnRejection (err, promise) {} // eslint-disable-line
  * const file = await a.single([ fetch(remoteFile), read(localFile) ])
  */
 async function single (list, ignore = 0) {
-  const results = await set(list, 1, ignore)
+  const results = await set(list, 1, ignore);
   return results[0]
 }
 
@@ -278,25 +261,25 @@ async function single (list, ignore = 0) {
 
 async function set (list, count = Infinity, ignore = 0) {
   return new Promise((resolve, reject) => {
-    const goal = Math.min(list.length, count)
-    const limit = Math.min(list.length - goal, ignore)
-    const results = []
-    const failures = new ErrorList('too many failures')
-    list.forEach(promise => promise.then(success).catch(error))
+    const goal = Math.min(list.length, count);
+    const limit = Math.min(list.length - goal, ignore);
+    const results = [];
+    const failures = new ErrorList('too many failures');
+    list.forEach(promise => promise.then(success).catch(error));
 
     function success (result) {
       if (failures.length > limit) return
-      results.push(result)
+      results.push(result);
       if (results.length === goal) {
-        resolve(results)
+        resolve(results);
       }
     }
     function error (err) {
       if (failures.length > limit) return
       if (results.length >= goal) return
-      failures.add(err)
+      failures.add(err);
       // TODO: reject with an Iterable custom Error that includes all failures
-      if (failures.length > limit) reject(failures)
+      if (failures.length > limit) reject(failures);
     }
   })
 }
@@ -317,27 +300,27 @@ async function set (list, count = Infinity, ignore = 0) {
  */
 async function list (list, ignore = 0) {
   return new Promise((resolve, reject) => {
-    const results = []
-    const failures = new ErrorList('too many failures')
-    const complete = () => count + failures.length === list.length
-    let count = 0
+    const results = [];
+    const failures = new ErrorList('too many failures');
+    const complete = () => count + failures.length === list.length;
+    let count = 0;
     list.forEach((promise, index) => {
-      promise.then(success).catch(error)
+      promise.then(success).catch(error);
 
       function success (result) {
         if (failures.length > ignore) return
-        results[index] = result
-        count++
-        if (complete()) resolve(results)
+        results[index] = result;
+        count++;
+        if (complete()) resolve(results);
       }
       function error (err) {
         if (failures.length > ignore) return
-        results[index] = undefined
-        failures.add(err)
-        if (failures.length > ignore) reject(failures)
-        else if (complete()) resolve(results)
+        results[index] = undefined;
+        failures.add(err);
+        if (failures.length > ignore) reject(failures);
+        else if (complete()) resolve(results);
       }
-    })
+    });
   })
 }
 
@@ -358,15 +341,15 @@ async function list (list, ignore = 0) {
  */
 
 async function object (container, ignore = 0) {
-  const containsPromise = key => typeof container[key].then === 'function'
-  const keys = Object.keys(container).filter(containsPromise)
-  const promises = keys.map(key => container[key])
-  const results = await list(promises, ignore)
-  const obj = Object.assign({}, container)
+  const containsPromise = key => typeof container[key].then === 'function';
+  const keys = Object.keys(container).filter(containsPromise);
+  const promises = keys.map(key => container[key]);
+  const results = await list(promises, ignore);
+  const obj = Object.assign({}, container);
   results.forEach((result, index) => {
-    const key = keys[index]
-    obj[key] = result
-  })
+    const key = keys[index];
+    obj[key] = result;
+  });
   return obj
 }
 
@@ -387,33 +370,33 @@ async function object (container, ignore = 0) {
  */
 async function map (list, concurrency, fn) {
   return new Promise((resolve, reject) => {
-    const results = []
-    let running = 0
-    let index = 0
+    const results = [];
+    let running = 0;
+    let index = 0;
 
-    update()
+    update();
 
     function update () {
       if (index === list.length && running === 0) {
         return resolve(results)
       }
       while (running < concurrency && index < list.length) {
-        fn(list[index]).then(success(index)).catch(error)
-        index++
-        running++
+        fn(list[index]).then(success(index)).catch(error);
+        index++;
+        running++;
       }
     }
     function success (i) {
       return result => {
-        running--
-        results[i] = result
-        update()
+        running--;
+        results[i] = result;
+        update();
       }
     }
     function error (err) {
-      running--
-      index = Infinity
-      reject(err)
+      running--;
+      index = Infinity;
+      reject(err);
     }
   })
 }
@@ -433,7 +416,7 @@ async function map (list, concurrency, fn) {
  */
 async function failure (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(() => resolve(undefined)).catch(resolve)
+    promise.then(() => resolve(undefined)).catch(resolve);
   })
 }
 
@@ -450,7 +433,7 @@ async function failure (promise) {
  */
 async function success (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(undefined)) // eslint-disable-line
+    promise.then(resolve).catch(err => resolve(undefined)); // eslint-disable-line
   })
 }
 
@@ -468,7 +451,7 @@ async function success (promise) {
  */
 async function result (promise) {
   return new Promise((resolve, reject) => {
-    promise.then(resolve).catch(err => resolve(err))
+    promise.then(resolve).catch(err => resolve(err));
   })
 }
 
@@ -496,9 +479,9 @@ async function result (promise) {
  * // =>    at Object.<anonymous> (/Users/hloftis/code/awaiting/test/fixtures/rejection-throw.js:4:1)
  */
 function throwRejections () {
-  process.removeListener('unhandledRejection', throwOnRejection)
-  process.removeListener('unhandledRejection', swallowOnRejection)
-  process.on('unhandledRejection', throwOnRejection)
+  process.removeListener('unhandledRejection', throwOnRejection);
+  process.removeListener('unhandledRejection', swallowOnRejection);
+  process.on('unhandledRejection', throwOnRejection);
 }
 
 /**
@@ -524,10 +507,29 @@ function throwRejections () {
  * // (no output)
  */
 function swallowRejections () {
-  process.removeListener('unhandledRejection', throwOnRejection)
-  process.removeListener('unhandledRejection', swallowOnRejection)
-  process.on('unhandledRejection', swallowOnRejection)
+  process.removeListener('unhandledRejection', throwOnRejection);
+  process.removeListener('unhandledRejection', swallowOnRejection);
+  process.on('unhandledRejection', swallowOnRejection);
 }
+
+exports.delay = delay;
+exports.time = time;
+exports.limit = limit;
+exports.event = event;
+exports.callback = callback;
+exports.single = single;
+exports.set = set;
+exports.list = list;
+exports.object = object;
+exports.map = map;
+exports.failure = failure;
+exports.success = success;
+exports.result = result;
+exports.awaited = awaited;
+exports.awaitable = awaited;
+exports.throw = throwRejections;
+exports.swallow = swallowRejections;
+exports.ErrorList = ErrorList;
 
 }).call(this,require('_process'))
 },{"_process":39}],2:[function(require,module,exports){
@@ -8617,6 +8619,10 @@ process.off = noop;
 process.removeListener = noop;
 process.removeAllListeners = noop;
 process.emit = noop;
+process.prependListener = noop;
+process.prependOnceListener = noop;
+
+process.listeners = function (name) { return [] }
 
 process.binding = function (name) {
     throw new Error('process.binding is not supported');

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,13 +27,6 @@ acorn@^4.0.1, acorn@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
-agent-base@2:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-2.0.1.tgz#bd8f9e86a8eb221fffa07bd14befd55df142815e"
-  dependencies:
-    extend "~3.0.0"
-    semver "~5.0.1"
-
 ajv-keywords@^1.0.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.0.tgz#c11e6859eafff83e0dafc416929472eca946aa2c"
@@ -1213,7 +1206,7 @@ character-reference-invalid@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.0.tgz#dec9ad1dfb9f8d06b4fcdaa2adc3c4fd97af1e68"
 
-chokidar@^1.2.0, chokidar@^1.4.3:
+chokidar@^1.2.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
   dependencies:
@@ -1228,7 +1221,7 @@ chokidar@^1.2.0, chokidar@^1.4.3:
   optionalDependencies:
     fsevents "^1.0.0"
 
-cipher-base@^1.0.0, cipher-base@^1.0.1:
+cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz#eeabf194419ce900da3018c207d212f2a6df0a07"
   dependencies:
@@ -1244,19 +1237,9 @@ cli-cursor@^1.0.1:
   dependencies:
     restore-cursor "^1.0.1"
 
-cli-table@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
-  dependencies:
-    colors "1.0.3"
-
 cli-width@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
-
-cliclopts@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/cliclopts/-/cliclopts-1.1.1.tgz#69431c7cb5af723774b0d3911b4c37512431910f"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1310,10 +1293,6 @@ collapse-white-space@^1.0.0, collapse-white-space@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.2.tgz#9c463fb9c6d190d2dcae21a356a01bcae9eeef6d"
 
-colors@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
-
 combine-source-map@~0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/combine-source-map/-/combine-source-map-0.7.2.tgz#0870312856b307a87cc4ac486f3a9a62aeccc09e"
@@ -1356,19 +1335,6 @@ concat-stream@^1.4.6, concat-stream@^1.5.0, concat-stream@~1.5.0, concat-stream@
     inherits "~2.0.1"
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
-
-configstore@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/configstore/-/configstore-1.4.0.tgz#c35781d0501d268c25c54b8b17f6240e8a4fb021"
-  dependencies:
-    graceful-fs "^4.1.2"
-    mkdirp "^0.5.0"
-    object-assign "^4.0.1"
-    os-tmpdir "^1.0.0"
-    osenv "^0.1.0"
-    uuid "^2.0.1"
-    write-file-atomic "^1.1.2"
-    xdg-basedir "^2.0.0"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -1421,21 +1387,25 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
-create-hash@^1.1.0, create-hash@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.1.2.tgz#51210062d7bb7479f6c65bb41a92208b1d61abad"
+create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.1.3.tgz#606042ac8b9262750f483caddab0f5819172d8fd"
   dependencies:
     cipher-base "^1.0.1"
     inherits "^2.0.1"
-    ripemd160 "^1.0.0"
-    sha.js "^2.3.6"
+    ripemd160 "^2.0.0"
+    sha.js "^2.4.0"
 
-create-hmac@^1.1.0, create-hmac@^1.1.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.4.tgz#d3fb4ba253eb8b3f56e39ea2fbcb8af747bd3170"
+create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.6.tgz#acb9e221a4e17bdb076e90657c42b93e3726cf06"
   dependencies:
+    cipher-base "^1.0.3"
     create-hash "^1.1.0"
     inherits "^2.0.1"
+    ripemd160 "^2.0.0"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
 
 cross-spawn@^4:
   version "4.0.2"
@@ -1495,7 +1465,7 @@ debug-log@^1.0.0, debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@2, debug@2.2.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@~2.2.0:
+debug@2.2.0, debug@^2.1.1, debug@^2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
@@ -1692,10 +1662,6 @@ duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2:
   dependencies:
     readable-stream "^2.0.2"
 
-duplexer@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
-
 duplexify@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.0.tgz#1aa773002e1578457e9d9d4a50b0ccaaebcbd604"
@@ -1771,10 +1737,6 @@ es6-map@^0.1.3:
     es6-set "~0.1.3"
     es6-symbol "~3.1.0"
     event-emitter "~0.3.4"
-
-es6-promise@^3.0.2:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
 
 es6-set@~0.1.3:
   version "0.1.4"
@@ -1914,18 +1876,6 @@ event-emitter@~0.3.4:
     d "~0.1.1"
     es5-ext "~0.10.7"
 
-event-stream@~3.3.0:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
-  dependencies:
-    duplexer "~0.1.1"
-    from "~0"
-    map-stream "~0.1.0"
-    pause-stream "0.0.11"
-    split "0.3"
-    stream-combiner "~0.0.4"
-    through "~2.3.1"
-
 events@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -1958,7 +1908,7 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extend@3, extend@^3.0.0, extend@~3.0.0:
+extend@^3.0.0, extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
@@ -2070,10 +2020,6 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
-
-from@~0:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/from/-/from-0.1.3.tgz#ef63ac2062ac32acf7862e0d40b44b896f22f3bc"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2256,21 +2202,6 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-got@^3.2.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/got/-/got-3.3.1.tgz#e5d0ed4af55fc3eef4d56007769d98192bcb2eca"
-  dependencies:
-    duplexify "^3.2.0"
-    infinity-agent "^2.0.0"
-    is-redirect "^1.0.0"
-    is-stream "^1.0.0"
-    lowercase-keys "^1.0.0"
-    nested-error-stacks "^1.0.0"
-    object-assign "^3.0.0"
-    prepend-http "^1.0.0"
-    read-all-stream "^3.0.0"
-    timed-out "^2.0.0"
-
 graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
@@ -2332,6 +2263,12 @@ has@^1.0.0, has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
+hash-base@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-2.0.2.tgz#66ea1d856db4e8a5470cadf6fce23ae5244ef2e1"
+  dependencies:
+    inherits "^2.0.1"
+
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.0.3.tgz#1332ff00156c0a0ffdd8236013d07b77a0451573"
@@ -2384,8 +2321,8 @@ highlight.js@^9.1.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.10.0.tgz#f9f0b14c0be00f0e4fb1e577b749fed9e6f52f55"
 
 hmac-drbg@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.0.tgz#3db471f45aae4a994a0688322171f51b8b91bee5"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   dependencies:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
@@ -2426,21 +2363,9 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
-https-proxy-agent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz#35f7da6c48ce4ddbfa264891ac593ee5ff8671e6"
-  dependencies:
-    agent-base "2"
-    debug "2"
-    extend "3"
-
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
-
-ignore-by-default@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
 
 ignore@^3.0.9, ignore@^3.2.0:
   version "3.2.0"
@@ -2453,10 +2378,6 @@ imurmurhash@^0.1.4:
 indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
-
-infinity-agent@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/infinity-agent/-/infinity-agent-2.0.3.tgz#45e0e2ff7a9eb030b27d62b74b3744b7a7ac4216"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -2641,10 +2562,6 @@ is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 
-is-npm@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
-
 is-number@^2.0.2, is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -2679,10 +2596,6 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
-is-redirect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
-
 is-relative@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-0.2.1.tgz#d27f4c7d516d175fb610db84bbeef23c3bc97aa5"
@@ -2701,7 +2614,7 @@ is-ssh@^1.3.0:
   dependencies:
     protocols "^1.1.0"
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -2742,10 +2655,6 @@ isarray@0.0.1, isarray@~0.0.1:
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-
-isemail@1.x.x:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-1.2.0.tgz#be03df8cc3e29de4d2c5df6501263f1fa4595e9a"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2813,29 +2722,13 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-joi@^6.9.1:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-6.10.1.tgz#4d50c318079122000fe5f16af1ff8e1917b77e06"
-  dependencies:
-    hoek "2.x.x"
-    isemail "1.x.x"
-    moment "2.x.x"
-    topo "1.x.x"
-
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@3.6.1:
+js-yaml@3.6.1, js-yaml@^3.3.1, js-yaml@^3.5.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^2.6.0"
-
-js-yaml@^3.3.1, js-yaml@^3.5.1:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
@@ -2925,12 +2818,6 @@ labeled-stream-splicer@^2.0.0:
     isarray "~0.0.1"
     stream-splicer "^2.0.0"
 
-latest-version@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-1.0.1.tgz#72cfc46e3e8d1be651e1ebb54ea9f6ea96f374bb"
-  dependencies:
-    package-json "^1.0.0"
-
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -3000,18 +2887,6 @@ lodash._basecreate@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
 
-lodash._bindcallback@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._createassigner@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz#838a5bae2fdaca63ac22dee8e19fa4e6d6970b11"
-  dependencies:
-    lodash._bindcallback "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
-    lodash.restparam "^3.0.0"
-
 lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
@@ -3020,14 +2895,6 @@ lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
 
-lodash.assign@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-3.2.0.tgz#3ce9f0234b4b2223e296b8fa0ac1fee8ebca64fa"
-  dependencies:
-    lodash._baseassign "^3.0.0"
-    lodash._createassigner "^3.0.0"
-    lodash.keys "^3.0.0"
-
 lodash.create@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
@@ -3035,13 +2902,6 @@ lodash.create@3.1.1:
     lodash._baseassign "^3.0.0"
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
-
-lodash.defaults@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-3.1.2.tgz#c7308b18dbf8bc9372d701a73493c61192bd2e2c"
-  dependencies:
-    lodash.assign "^3.0.0"
-    lodash.restparam "^3.0.0"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -3066,10 +2926,6 @@ lodash.keys@^3.0.0:
 lodash.memoize@~3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
-
-lodash.restparam@^3.0.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
 lodash@^4.0.0, lodash@^4.11.1, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
@@ -3099,10 +2955,6 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0"
 
-lowercase-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
-
 lru-cache@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
@@ -3113,10 +2965,6 @@ lru-cache@^4.0.1:
 map-cache@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
-
-map-stream@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
 
 markdown-escapes@^1.0.0:
   version "1.0.0"
@@ -3333,10 +3181,6 @@ module-deps@^4.0.8:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-moment@2.x.x:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
-
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -3353,12 +3197,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-nested-error-stacks@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz#19f619591519f096769a5ba9a86e6eeec823c3cf"
-  dependencies:
-    inherits "~2.0.1"
-
 node-pre-gyp@^0.6.29:
   version "0.6.32"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz#fc452b376e7319b3d255f5f34853ef6fd8fe1fd5"
@@ -3372,31 +3210,6 @@ node-pre-gyp@^0.6.29:
     semver "~5.3.0"
     tar "~2.2.1"
     tar-pack "~3.3.0"
-
-nodemon@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.11.0.tgz#226c562bd2a7b13d3d7518b49ad4828a3623d06c"
-  dependencies:
-    chokidar "^1.4.3"
-    debug "^2.2.0"
-    es6-promise "^3.0.2"
-    ignore-by-default "^1.0.0"
-    lodash.defaults "^3.1.2"
-    minimatch "^3.0.0"
-    ps-tree "^1.0.1"
-    touch "1.0.0"
-    undefsafe "0.0.3"
-    update-notifier "0.5.0"
-
-nodesecurity-npm-utils@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/nodesecurity-npm-utils/-/nodesecurity-npm-utils-5.0.0.tgz#05aa30de30ca8c845c4048e94fd78e5e08b55ed9"
-
-nopt@~1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
-  dependencies:
-    abbrev "1"
 
 nopt@~3.0.6:
   version "3.0.6"
@@ -3438,21 +3251,6 @@ npmlog@^4.0.1:
     gauge "~2.7.1"
     set-blocking "~2.0.0"
 
-nsp@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/nsp/-/nsp-2.6.2.tgz#93dfb4c5b2885cc354d8ca18b73f09e52b9c8b16"
-  dependencies:
-    chalk "^1.1.1"
-    cli-table "^0.3.1"
-    https-proxy-agent "^1.0.0"
-    joi "^6.9.1"
-    nodesecurity-npm-utils "^5.0.0"
-    path-is-absolute "^1.0.0"
-    rc "^1.1.2"
-    semver "^5.0.3"
-    subcommand "^2.0.3"
-    wreck "^6.3.0"
-
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -3492,10 +3290,6 @@ nyc@^10.2.0:
 oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
-
-object-assign@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
 object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
@@ -3571,23 +3365,9 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-
-osenv@^0.1.0:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.0"
-
-package-json@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/package-json/-/package-json-1.2.0.tgz#c8ecac094227cdf76a316874ed05e27cc939a0e0"
-  dependencies:
-    got "^3.2.0"
-    registry-url "^3.0.0"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -3694,17 +3474,15 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-pause-stream@0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
-  dependencies:
-    through "~2.3"
-
 pbkdf2@^3.0.3:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.9.tgz#f2c4b25a600058b3c3773c086c37dbbee1ffe693"
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.12.tgz#be36785c5067ea48d806ff923288c5f750b6b8a2"
   dependencies:
-    create-hmac "^1.1.2"
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+    ripemd160 "^2.0.1"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -3748,10 +3526,6 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-prepend-http@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
-
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
@@ -3765,8 +3539,8 @@ process-nextick-args@^1.0.6, process-nextick-args@~1.0.6:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
 process@~0.11.0:
-  version "0.11.9"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.9.tgz#7bd5ad21aa6253e7da8682264f1e11d11c0318c1"
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
 progress@^1.1.8:
   version "1.1.8"
@@ -3779,12 +3553,6 @@ property-information@^3.1.0:
 protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.5.tgz#21de1f441c4ef7094408ed9f1c94f7a114b87557"
-
-ps-tree@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
-  dependencies:
-    event-stream "~3.3.0"
 
 pseudomap@^1.0.1:
   version "1.0.2"
@@ -3845,7 +3613,7 @@ raw-body@~1.1.0:
     bytes "1"
     string_decoder "0.10"
 
-rc@^1.0.1, rc@^1.1.0, rc@^1.1.2, rc@~1.1.6:
+rc@^1.1.0, rc@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.1.6.tgz#43651b76b6ae53b5c802f1151fa3fc3b059969c9"
   dependencies:
@@ -3853,13 +3621,6 @@ rc@^1.0.1, rc@^1.1.0, rc@^1.1.2, rc@~1.1.6:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
-
-read-all-stream@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/read-all-stream/-/read-all-stream-3.1.0.tgz#35c3e177f2078ef789ee4bfafa4373074eaef4fa"
-  dependencies:
-    pinkie-promise "^2.0.0"
-    readable-stream "^2.0.0"
 
 read-only-stream@^2.0.0:
   version "2.0.0"
@@ -3891,51 +3652,7 @@ read-pkg@^1.0.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.1.5, readable-stream@^2.2.6:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.7.tgz#07057acbe2467b22042d36f98c5ad507054e95b1"
-  dependencies:
-    buffer-shims "~1.0.0"
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~1.0.0"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.0.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
-  dependencies:
-    buffer-shims "^1.0.0"
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
-readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
-readable-stream@~2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
-readable-stream@~2.1.0, readable-stream@~2.1.4:
+readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.1.5, readable-stream@~2.1.0, readable-stream@~2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
   dependencies:
@@ -3946,6 +3663,38 @@ readable-stream@~2.1.0, readable-stream@~2.1.4:
     process-nextick-args "~1.0.6"
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
+
+readable-stream@^2.0.2, readable-stream@~2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.2.6:
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8"
+  dependencies:
+    buffer-shims "~1.0.0"
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~1.0.0"
+    util-deprecate "~1.0.1"
+
+readable-stream@~1.1.9:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readdirp@^2.0.0:
   version "2.1.0"
@@ -4000,12 +3749,6 @@ regexpu-core@^2.0.0:
     regenerate "^1.2.1"
     regjsgen "^0.2.0"
     regjsparser "^0.1.4"
-
-registry-url@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
-  dependencies:
-    rc "^1.0.1"
 
 regjsgen@^0.2.0:
   version "0.2.0"
@@ -4108,12 +3851,6 @@ repeat-string@^1.5.0, repeat-string@^1.5.2, repeat-string@^1.5.4:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
-repeating@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-1.1.3.tgz#3d4114218877537494f97f77f9785fab810fa4ac"
-  dependencies:
-    is-finite "^1.0.0"
-
 repeating@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
@@ -4203,9 +3940,18 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.4.4, rimraf@^2.5.4, rimraf@~2.
   dependencies:
     glob "^7.0.5"
 
-ripemd160@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
+ripemd160@^2.0.0, ripemd160@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"
+  dependencies:
+    hash-base "^2.0.0"
+    inherits "^2.0.1"
+
+rollup@^0.41.6:
+  version "0.41.6"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.41.6.tgz#e0d05497877a398c104d816d2733a718a7a94e2a"
+  dependencies:
+    source-map-support "^0.4.0"
 
 run-async@^0.1.0:
   version "0.1.0"
@@ -4221,23 +3967,17 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+safe-buffer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
 safe-json-parse@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-json-parse/-/safe-json-parse-1.0.1.tgz#3e76723e38dfdda13c9b1d29a1e07ffee4b30b57"
 
-semver-diff@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
-  dependencies:
-    semver "^5.0.3"
-
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.3.0, semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-
-semver@~5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -4247,7 +3987,7 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
-sha.js@^2.3.6, sha.js@~2.4.4:
+sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
   version "2.4.8"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
@@ -4307,7 +4047,7 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
-source-map-support@^0.4.2:
+source-map-support@^0.4.0, source-map-support@^0.4.2:
   version "0.4.14"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.14.tgz#9d4463772598b86271b4f523f6c1f4e02a7d6aef"
   dependencies:
@@ -4353,12 +4093,6 @@ spdx-expression-parse@~1.0.0:
 spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
-
-split@0.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
-  dependencies:
-    through "2"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -4426,15 +4160,9 @@ stream-combiner2@^1.1.1:
     duplexer2 "~0.1.0"
     readable-stream "^2.0.2"
 
-stream-combiner@~0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
-  dependencies:
-    duplexer "~0.1.1"
-
 stream-http@^2.0.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.0.tgz#cec1f4e3b494bc4a81b451808970f8b20b4ed5f6"
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.1.tgz#546a51741ad5a6b07e9e31b0b10441a917df528a"
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
@@ -4452,12 +4180,6 @@ stream-splicer@^2.0.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
-
-string-length@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string-length/-/string-length-1.0.1.tgz#56970fb1c38558e9e70b728bf3de269ac45adfac"
-  dependencies:
-    strip-ansi "^3.0.0"
 
 string-template@~0.2.1:
   version "0.2.1"
@@ -4483,10 +4205,10 @@ string_decoder@0.10, string_decoder@~0.10.0, string_decoder@~0.10.x:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
 string_decoder@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.1.tgz#62e200f039955a6810d8df0a33ffc0f013662d98"
   dependencies:
-    buffer-shims "~1.0.0"
+    safe-buffer "^5.0.1"
 
 stringify-entities@^1.0.1:
   version "1.3.0"
@@ -4538,15 +4260,6 @@ subarg@^1.0.0:
   resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
   dependencies:
     minimist "^1.1.0"
-
-subcommand@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/subcommand/-/subcommand-2.1.0.tgz#5e4ceca5a3779e3365b1511e05f866877302f760"
-  dependencies:
-    cliclopts "^1.1.0"
-    debug "^2.1.3"
-    minimist "^1.2.0"
-    xtend "^4.0.0"
 
 supports-color@3.1.2, supports-color@^3.1.2:
   version "3.1.2"
@@ -4642,13 +4355,9 @@ through2@~0.2.1:
     readable-stream "~1.1.9"
     xtend "~2.1.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3, through@~2.3.1:
+"through@>=2.2.7 <3", through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-
-timed-out@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-2.0.0.tgz#f38b0ae81d3747d628001f41dafc652ace671c0a"
 
 timers-browserify@^1.0.1:
   version "1.4.2"
@@ -4684,18 +4393,6 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
-
-topo@1.x.x:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
-  dependencies:
-    hoek "2.x.x"
-
-touch@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/touch/-/touch-1.0.0.tgz#449cbe2dbae5a8c8038e30d71fa0ff464947c4de"
-  dependencies:
-    nopt "~1.0.10"
 
 tough-cookie@~2.3.0:
   version "2.3.2"
@@ -4782,10 +4479,6 @@ unc-path-regex@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
 
-undefsafe@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-0.0.3.tgz#ecca3a03e56b9af17385baac812ac83b994a962f"
-
 unherit@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.0.tgz#6b9aaedfbf73df1756ad9e316dd981885840cd7d"
@@ -4859,18 +4552,6 @@ untildify@^2.1.0:
   dependencies:
     os-homedir "^1.0.0"
 
-update-notifier@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-0.5.0.tgz#07b5dc2066b3627ab3b4f530130f7eddda07a4cc"
-  dependencies:
-    chalk "^1.0.0"
-    configstore "^1.0.0"
-    is-npm "^1.0.0"
-    latest-version "^1.0.0"
-    repeating "^1.1.2"
-    semver-diff "^2.0.0"
-    string-length "^1.0.0"
-
 url@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -4893,10 +4574,6 @@ util@0.10.3, util@~0.10.1:
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:
     inherits "2.0.1"
-
-uuid@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 uuid@^3.0.0:
   version "3.0.1"
@@ -5051,14 +4728,7 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-wreck@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/wreck/-/wreck-6.3.0.tgz#a1369769f07bbb62d6a378336a7871fc773c740b"
-  dependencies:
-    boom "2.x.x"
-    hoek "2.x.x"
-
-write-file-atomic@^1.1.2, write-file-atomic@^1.1.4:
+write-file-atomic@^1.1.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.1.tgz#7d45ba32316328dd1ec7d90f60ebc0d845bb759a"
   dependencies:
@@ -5075,12 +4745,6 @@ write@^0.2.1:
 x-is-string@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
-
-xdg-basedir@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-2.0.0.tgz#edbc903cc385fc04523d966a335504b5504d1bd2"
-  dependencies:
-    os-homedir "^1.0.0"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
This should resolve #7 and #12 

I don't use ES6 modules myself since they aren't supported by any browser, or node, so I haven't done any dogfooding here. I'd appreciate feedback from @AutoSponge, @backspaces, and @tunnckoCore re: this implementation. I want to keep it as simple as possible.

* `lib/awaiting.js` => ES6 export syntax
* `dist/awaiting.common.js` => generated for node
* `dist/awaiting.umd.js` => generated for browsers
* tests use `..` syntax (package.json:main, which directs to the common.js module)